### PR TITLE
[Fix]: Comments' sort by top algorithm throws SQLSTATE(42703) error in pgsql

### DIFF
--- a/database/migrations/drop_guest_columns_from_comments_table.php.stub
+++ b/database/migrations/drop_guest_columns_from_comments_table.php.stub
@@ -11,7 +11,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('comments', function (Blueprint $table) {
-            // First we need to drop indexes f exists
+            // First we need to drop indexes if exists
 
             $indexes = [
                 'comments_guest_name_index',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,6 @@ includes:
     - vendor/larastan/larastan/extension.neon
 
 parameters:
-
     paths:
         - src/
 

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -3,10 +3,13 @@
 namespace LakM\Comments\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\DB;
 use LakM\Comments\Builders\MessageBuilder;
+use LakM\Comments\ModelResolver;
 use LakM\Comments\ModelResolver as M;
 use LakM\Comments\Models\Concerns\HasOwner;
 use LakM\Comments\Models\Concerns\HasProfilePhoto;
@@ -50,5 +53,36 @@ class Comment extends Message
     public function replyReactions(): HasManyThrough
     {
         return $this->hasManyThrough(M::reactionClass(), Reply::class, 'reply_id', 'comment_id');
+    }
+
+    public function scopeAddScore(Builder $query): Builder
+    {
+        $reactionsTable = ModelResolver::reactionModel()->getTable();
+        $commentsTable = ModelResolver::commentModel()->getTable();
+
+        $reactionsCount = "(select count(*) from {$reactionsTable} where
+            {$commentsTable}.id = {$reactionsTable}.comment_id)";
+
+        $dislikesCountQuery = "(select (count(*) * 2) from {$reactionsTable} where
+            {$commentsTable}.id = {$reactionsTable}.comment_id and type = 'dislike')";
+
+        $repliesCountQuery = "(select (count(*) * 2) from {$commentsTable} as laravel_reserved_0 where
+            {$commentsTable}.id = laravel_reserved_0.reply_id)";
+
+        $replyReactionsCount = "(select count(*) from {$reactionsTable} inner join {$commentsTable} as laravel_reserved_1
+            on laravel_reserved_1.id = {$reactionsTable}.comment_id where {$commentsTable}.id = laravel_reserved_1.reply_id)";
+
+        $replyReactionsDislikeCount = "(select (count(*) * 2) from  {$reactionsTable}  inner join {$commentsTable} as laravel_reserved_2
+            on laravel_reserved_2.id = {$reactionsTable}.comment_id  where  {$commentsTable}.id = laravel_reserved_2.reply_id and
+            type = 'dislike')";
+
+        return $query->addSelect(DB::raw('(select ' .
+            $reactionsCount . ' + ' .
+            $repliesCountQuery . ' + ' .
+            $replyReactionsCount . ' - '.
+            $dislikesCountQuery . ' - ' .
+            $replyReactionsDislikeCount . ') ' .
+            'as score')
+        );
     }
 }

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -24,6 +24,7 @@ use LakM\Comments\Models\Concerns\HasProfilePhoto;
  * @property Carbon $updated_at
  *
  * @method MessageBuilder<Comment> query()
+ * @method Builder addScore()
  */
 class Comment extends Message
 {
@@ -76,7 +77,8 @@ class Comment extends Message
             on laravel_reserved_2.id = {$reactionsTable}.comment_id  where  {$commentsTable}.id = laravel_reserved_2.reply_id and
             type = 'dislike')";
 
-        return $query->addSelect(DB::raw('(select ' .
+        return $query->addSelect(
+            DB::raw('(select ' .
             $reactionsCount . ' + ' .
             $repliesCountQuery . ' + ' .
             $replyReactionsCount . ' - '.

--- a/src/Queries.php
+++ b/src/Queries.php
@@ -88,6 +88,7 @@ class Queries extends AbstractQueries
                 return $query->orderByDesc('replies_count');
             })
             ->when($sortBy === Sort::TOP, function (Builder $query) {
+                // @phpstan-ignore-next-line
                 return $query
                     ->addScore()
                     ->orderByDesc("score");

--- a/src/Queries.php
+++ b/src/Queries.php
@@ -33,8 +33,8 @@ class Queries extends AbstractQueries
     }
 
     /**
-     * @param  Authenticatable&CommenterContract  $user
-     * @param  Model&CommentableContract  $relatedModel
+     * @param Authenticatable&CommenterContract $user
+     * @param Model&CommentableContract $relatedModel
      * @return int
      */
     public static function userCommentCount(Authenticatable $user, Model $relatedModel): int
@@ -59,7 +59,7 @@ class Queries extends AbstractQueries
         ?int $limit,
         Sort $sortBy,
         string $filter = ''
-    ): LengthAwarePaginator|Collection {
+    ): LengthAwarePaginator|Collection{
         /** @var MessageBuilder<Comment> $commentQuery */
         $commentQuery = $relatedModel->comments();
 
@@ -72,7 +72,7 @@ class Queries extends AbstractQueries
                 'replies' => function (MessageBuilder $query) {
                     $query->when(
                         config('comments.reply.approval_required'),
-                        fn (MessageBuilder $query) => $query->approved()
+                        fn(MessageBuilder $query) => $query->approved()
                     );
                 },
             ])
@@ -88,14 +88,9 @@ class Queries extends AbstractQueries
                 return $query->orderByDesc('replies_count');
             })
             ->when($sortBy === Sort::TOP, function (Builder $query) {
-                return $query->withCount([
-                    'reactions',
-                    'replyReactions',
-                    'replyReactions as reply_reactions_dislikes_count' => function (Builder $query) {
-                        $query->where('type', 'dislike');
-                    },
-                ])
-                    ->orderByDesc(DB::raw('reactions_count - (dislikes_count * 2) + (replies_count * 2) + reply_reactions_count - (reply_reactions_dislikes_count * 2)'));
+                return $query
+                    ->addScore()
+                    ->orderByDesc("score");
             })
             ->when(
                 $relatedModel->paginationEnabled(),
@@ -119,18 +114,19 @@ class Queries extends AbstractQueries
     }
 
     /**
-     * @param  Reply|Comment  $comment
-     * @param  string  $reactionType
-     * @param  int  $limit
-     * @param  bool  $authMode
+     * @param Reply|Comment $comment
+     * @param string $reactionType
+     * @param int $limit
+     * @param bool $authMode
      * @return \Illuminate\Support\Collection<int, UserData>
      */
     public static function reactedUsers(
         Reply|Comment $comment,
-        string $reactionType,
-        int $limit,
-        bool $authMode
-    ): \Illuminate\Support\Collection {
+        string        $reactionType,
+        int           $limit,
+        bool          $authMode
+    ): \Illuminate\Support\Collection
+    {
         /** @var ReactionBuilder<Reaction> $reactionQuery */
         $reactionQuery = $comment->reactions();
 
@@ -169,35 +165,36 @@ class Queries extends AbstractQueries
         $replyQuery = $comment->replies();
 
         return $replyQuery
-                ->when(
-                    !$guestMode,
-                    function (MessageBuilder $query) use ($user) {
-                        $query->currentUser($user);
-                    },
-                    function (MessageBuilder $query) {
-                        $query->currentGuest();
-                    }
-                )
-                ->count();
+            ->when(
+                !$guestMode,
+                function (MessageBuilder $query) use ($user) {
+                    $query->currentUser($user);
+                },
+                function (MessageBuilder $query) {
+                    $query->currentGuest();
+                }
+            )
+            ->count();
     }
 
     /**
-     * @param  Comment  $comment
-     * @param  Model&CommentableContract  $relatedModel
-     * @param  bool  $approvalRequired
-     * @param  int  $limit
-     * @param  Sort  $sortBy
-     * @param  string  $filter
+     * @param Comment $comment
+     * @param Model&CommentableContract $relatedModel
+     * @param bool $approvalRequired
+     * @param int $limit
+     * @param Sort $sortBy
+     * @param string $filter
      * @return LengthAwarePaginator|Collection
      */
     public static function commentReplies(
         Comment $comment,
-        Model $relatedModel,
-        bool $approvalRequired,
-        ?int $limit,
-        Sort $sortBy,
-        string $filter = ''
-    ): LengthAwarePaginator|Collection {
+        Model   $relatedModel,
+        bool    $approvalRequired,
+        ?int    $limit,
+        Sort    $sortBy,
+        string  $filter = ''
+    ): LengthAwarePaginator|Collection
+    {
         /** @var MessageBuilder<Reply> $replyQuery */
         $replyQuery = $comment->replies();
 
@@ -205,8 +202,8 @@ class Queries extends AbstractQueries
             ->currentUserFilter($relatedModel, $filter)
             ->with('commenter')
             ->withOwnerReactions($relatedModel)
-            ->when(!$relatedModel->guestModeEnabled(), fn (MessageBuilder $query) => $query->with('commenter'))
-            ->when($approvalRequired, fn (MessageBuilder $query) => $query->approved())
+            ->when(!$relatedModel->guestModeEnabled(), fn(MessageBuilder $query) => $query->with('commenter'))
+            ->when($approvalRequired, fn(MessageBuilder $query) => $query->approved())
             ->when($sortBy === Sort::LATEST, function (Builder $query) {
                 return $query->latest();
             })
@@ -217,8 +214,8 @@ class Queries extends AbstractQueries
             ->latest()
             ->when(
                 config('comments.reply.pagination.enabled'),
-                fn (Builder $query) => $query->paginate($limit),
-                fn (Builder $query) => $query->get()
+                fn(Builder $query) => $query->paginate($limit),
+                fn(Builder $query) => $query->get()
             );
     }
 
@@ -240,11 +237,11 @@ class Queries extends AbstractQueries
             ->limit($limit)
             ->get()
             ->transform(
-                /**
-                 * @param  User&CommenterContract  $user
-                 * @return UserData
-                 * @phpstan-ignore-next-line
-                 */
+            /**
+             * @param User&CommenterContract $user
+             * @return UserData
+             * @phpstan-ignore-next-line
+             */
                 function (User $user) {
                     // @phpstan-ignore-next-line
                     return new UserData(name: $user->name(), photo: $user->photoUrl());


### PR DESCRIPTION
Refer the issue #51 

**Reason**

PgSQL cannot refer derived columns.