### PR TITLE
Bug fix: add missing parameter

### DIFF
--- a/resources/views/livewire/reactions-manager.blade.php
+++ b/resources/views/livewire/reactions-manager.blade.php
@@ -167,7 +167,7 @@
                         />
                     </div>
                 @else
-                    <x-comments::show-reaction :$comment :$lastReactedUserName :$reactions :$key :$authMode :$secureGuestModeAllowed/>
+                    <x-comments::show-reaction :$comment :$lastReactedUserName :$reactions :$key :$authMode :$loginRequired :$secureGuestModeAllowed/>
                 @endif
             @endforeach
 


### PR DESCRIPTION
The parameter :$loginRequired is missing in show-reaction component, and this causes a bug when setting the reaction reply’s aligned to the left side.