### PR TITLE
Add missing localization to Blade component strings

### DIFF
--- a/resources/views/components/link-visit-confirm-modal.blade.php
+++ b/resources/views/components/link-visit-confirm-modal.blade.php
@@ -31,16 +31,16 @@
     <x-comments::modal class="!w-[32rem]">
         <div class="px-4 py-2 space-y-6">
             <div class="flex flex-col items-center space-y-2">
-                <span class="font-bold text-xl">{{ __('Leaving :app', ['app' => config('app.name')]) }}</span>
-                <span x-show="isURLValid">@lang('Your about to visit the following url')</span>
-                <span x-show="!isURLValid">@lang('Invalid URL')</span>
+                <span class="font-bold text-xl">{{ __('Leaving') }} {{ config('app.name') }}</span>
+                <span x-show="isURLValid">{{ __('Your about to visit the following url') }}</span>
+                <span x-show="!isURLValid">{{ __('Invalid URL') }}</span>
             </div>
             <div class="border p-4 rounded">
                 <p class="overflow-auto break-all"><span x-text=protocol></span><strong x-text="domain"></strong><span x-text="path"></span></p>
             </div>
             <div x-show="isURLValid" @click="window.open(fullUrl, '_blank')" class="flex justify-end">
                 <x-comments::button size="md" type="button">
-                    @lang('Visit Site')
+                    {{ __('Visit Site') }}
                 </x-comments::button>
             </div>
         </div>

--- a/resources/views/components/link-visit-confirm-modal.blade.php
+++ b/resources/views/components/link-visit-confirm-modal.blade.php
@@ -31,16 +31,16 @@
     <x-comments::modal class="!w-[32rem]">
         <div class="px-4 py-2 space-y-6">
             <div class="flex flex-col items-center space-y-2">
-                <span class="font-bold text-xl">Leaving {{config('app.name')}}</span>
-                <span x-show="isURLValid">Your about to visit the following url</span>
-                <span x-show="!isURLValid">Invalid URL</span>
+                <span class="font-bold text-xl">{{ __('Leaving :app', ['app' => config('app.name')]) }}</span>
+                <span x-show="isURLValid">@lang('Your about to visit the following url')</span>
+                <span x-show="!isURLValid">@lang('Invalid URL')</span>
             </div>
             <div class="border p-4 rounded">
                 <p class="overflow-auto break-all"><span x-text=protocol></span><strong x-text="domain"></strong><span x-text="path"></span></p>
             </div>
             <div x-show="isURLValid" @click="window.open(fullUrl, '_blank')" class="flex justify-end">
                 <x-comments::button size="md" type="button">
-                    Visit Site
+                    @lang('Visit Site')
                 </x-comments::button>
             </div>
         </div>

--- a/resources/views/components/show-reacted-users.blade.php
+++ b/resources/views/components/show-reacted-users.blade.php
@@ -21,10 +21,10 @@
                 <span>
                     {{ Str::limit($lastReactedUserName, 10) }}
                     @if ($reactions[$key]['count'] > 1)
-                        @lang('and') {{ $reactions[$key]['count'] - 1 }} @lang('other')
+                        {{ __('and') }} {{ $reactions[$key]['count'] - 1 }} {{ __('other') }}
                     @endif
 
-                    @lang('reacted.')
+                    {{ __('reacted.') }}
                 </span>
                 @if ($reactions[$key]['count'] > 1)
                     <span
@@ -32,7 +32,7 @@
                         @click="$dispatch('show-user-list', {id: '{{ $comment->getKey() }}', type: '{{ $key }}'})"
                         class="w-full cursor-pointer pb-1 text-center"
                     >
-                        <x-comments::link type="popup">@lang('show all')</x-comments::link>
+                        <x-comments::link type="popup">{{ __('show all') }}</x-comments::link>
                     </span>
                 @endif
             </div>

--- a/resources/views/components/show-reacted-users.blade.php
+++ b/resources/views/components/show-reacted-users.blade.php
@@ -21,10 +21,10 @@
                 <span>
                     {{ Str::limit($lastReactedUserName, 10) }}
                     @if ($reactions[$key]['count'] > 1)
-                        and {{ $reactions[$key]['count'] - 1 }} other
+                        @lang('and') {{ $reactions[$key]['count'] - 1 }} @lang('other')
                     @endif
 
-                    reacted.
+                    @lang('reacted.')
                 </span>
                 @if ($reactions[$key]['count'] > 1)
                     <span
@@ -32,7 +32,7 @@
                         @click="$dispatch('show-user-list', {id: '{{ $comment->getKey() }}', type: '{{ $key }}'})"
                         class="w-full cursor-pointer pb-1 text-center"
                     >
-                        <x-comments::link type="popup">show all</x-comments::link>
+                        <x-comments::link type="popup">@lang('show all')</x-comments::link>
                     </span>
                 @endif
             </div>

--- a/resources/views/components/show-reacted-users.blade.php
+++ b/resources/views/components/show-reacted-users.blade.php
@@ -24,7 +24,7 @@
                         {{ __('and') }} {{ $reactions[$key]['count'] - 1 }} {{ __('other') }}
                     @endif
 
-                    {{ __('reacted.') }}
+                    {{ __('reacted') }}.
                 </span>
                 @if ($reactions[$key]['count'] > 1)
                     <span

--- a/resources/views/components/spin.blade.php
+++ b/resources/views/components/spin.blade.php
@@ -8,5 +8,5 @@
     role="status"
     aria-label="loading"
 >
-    <span class="sr-only">Loading...</span>
+    <span class="sr-only">@lang('Loading...')</span>
 </span>

--- a/resources/views/components/spin.blade.php
+++ b/resources/views/components/spin.blade.php
@@ -8,5 +8,5 @@
     role="status"
     aria-label="loading"
 >
-    <span class="sr-only">@lang('Loading...')</span>
+    <span class="sr-only">{{ __('Loading...') }}</span>
 </span>

--- a/resources/views/components/spin.blade.php
+++ b/resources/views/components/spin.blade.php
@@ -8,5 +8,5 @@
     role="status"
     aria-label="loading"
 >
-    <span class="sr-only">{{ __('Loading...') }}</span>
+    <span class="sr-only">{{ __('Loading') }}...</span>
 </span>


### PR DESCRIPTION
Replaced hardcoded text with __('') helpers across Blade components. This ensures better translation support and aligns text with language file definitions for improved internationalization.