### PR TITLE
Add title attribute to display exact date-time

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -26,7 +26,6 @@ hljs.configure({
 
 window.hljs = hljs;
 
-import '../css/app.css';
 import 'quill/dist/quill.snow.css';
 import 'highlight.js/styles/github.css';
 

--- a/resources/views/components/index.blade.php
+++ b/resources/views/components/index.blade.php
@@ -2,17 +2,20 @@
     'model',
 ])
 
-<div
-    x-cloak
-    x-data
-    class="space-y-8 dark:text-white lakm_commenter"
->
-    @if(config('comments.should_confirm_link_visit'))
-        <x-comments::link-visit-confirm-modal/>
-    @endif
-    <livewire:comments-list :model="$model"/>
-    <hr class="text-gray-400"/>
-    <div id="create-comment-form">
-        <livewire:comments-create-form :model="$model"/>
+<div class="lakm_commenter">
+    <div
+        x-cloak
+        x-data
+        class="space-y-8 dark:text-white"
+    >
+        @if(config('comments.should_confirm_link_visit'))
+            <x-comments::link-visit-confirm-modal/>
+        @endif
+        <livewire:comments-list :model="$model"/>
+        <hr class="text-gray-400"/>
+        <div id="create-comment-form">
+            <livewire:comments-create-form :model="$model"/>
+        </div>
     </div>
 </div>
+

--- a/resources/views/livewire/comment-item.blade.php
+++ b/resources/views/livewire/comment-item.blade.php
@@ -97,7 +97,12 @@
                             <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                             @if (config('comments.date_format') === 'diff')
-                                <span class="text-xs" x-bind:title="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')">{{ $comment->created_at->diffForHumans() }}</span>
+                                <span
+                                    class="text-xs"
+                                    :title="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')"
+                                >
+                                    {{ $comment->created_at->diffForHumans() }}
+                                </span>
                             @else
                                 <span
                                     x-text="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/comment-item.blade.php
+++ b/resources/views/livewire/comment-item.blade.php
@@ -97,7 +97,7 @@
                             <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                             @if (config('comments.date_format') === 'diff')
-                                <span class="text-xs">{{ $comment->created_at->diffForHumans() }}</span>
+                                <span class="text-xs" x-bind:title="moment(@js($comment->created_at)).format('YYYY-MM-DD HH:mm')">{{ $comment->created_at->diffForHumans() }}</span>
                             @else
                                 <span
                                     x-text="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/comment-item.blade.php
+++ b/resources/views/livewire/comment-item.blade.php
@@ -97,7 +97,7 @@
                             <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                             @if (config('comments.date_format') === 'diff')
-                                <span class="text-xs" x-bind:title="moment(@js($comment->created_at)).format('YYYY-MM-DD HH:mm')">{{ $comment->created_at->diffForHumans() }}</span>
+                                <span class="text-xs" x-bind:title="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')">{{ $comment->created_at->diffForHumans() }}</span>
                             @else
                                 <span
                                     x-text="moment(@js($comment->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/comment-reply-item.blade.php
+++ b/resources/views/livewire/comment-reply-item.blade.php
@@ -77,7 +77,7 @@
                         <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                         @if (config('comments.date_format') === 'diff')
-                            <span class="text-xs" x-bind:title="moment(@js($reply->created_at)).format('YYYY-MM-DD HH:mm')">{{ $reply->created_at->diffForHumans() }}</span>
+                            <span class="text-xs" x-bind:title="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')">{{ $reply->created_at->diffForHumans() }}</span>
                         @else
                             <span
                                 x-text="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/comment-reply-item.blade.php
+++ b/resources/views/livewire/comment-reply-item.blade.php
@@ -77,7 +77,11 @@
                         <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                         @if (config('comments.date_format') === 'diff')
-                            <span class="text-xs" x-bind:title="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')">{{ $reply->created_at->diffForHumans() }}</span>
+                            <span
+                                class="text-xs"
+                                :title="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')">
+                                {{ $reply->created_at->diffForHumans() }}
+                            </span>
                         @else
                             <span
                                 x-text="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/comment-reply-item.blade.php
+++ b/resources/views/livewire/comment-reply-item.blade.php
@@ -77,7 +77,7 @@
                         <span class="inline-block h-2 w-[1px] bg-black mr-1"></span>
 
                         @if (config('comments.date_format') === 'diff')
-                            <span class="text-xs">{{ $reply->created_at->diffForHumans() }}</span>
+                            <span class="text-xs" x-bind:title="moment(@js($reply->created_at)).format('YYYY-MM-DD HH:mm')">{{ $reply->created_at->diffForHumans() }}</span>
                         @else
                             <span
                                 x-text="moment(@js($reply->created_at)).format('YYYY/M/D H:mm')"

--- a/resources/views/livewire/editor.blade.php
+++ b/resources/views/livewire/editor.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <div wire:ignore class="relative dark:text-white">
+    <div wire:ignore class="relative dark:text-white dark:bg-black">
         <div @click.stop id="{{ $editorId }}" class="min-h-32 rounded rounded-t-none pointer-events"></div>
         <div id="{{ $toolbarId }}" class="w-full"></div>
 

--- a/src/CommentServiceProvider.php
+++ b/src/CommentServiceProvider.php
@@ -86,7 +86,7 @@ class CommentServiceProvider extends ServiceProvider
 
         $styles = Vite::useBuildDirectory("vendor/lakm/laravel-comments/build")
             ->useHotFile('vendor/lakm/laravel-comments/laravel-comments.hot')
-            ->withEntryPoints(['resources/js/app.js'])
+            ->withEntryPoints(['resources/css/app.css'])
             ->toHtml();
 
         $scripts = Vite::useBuildDirectory("vendor/lakm/laravel-comments/build")

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,5 +15,9 @@ export default {
     },
     plugins: [],
     darkMode: ['selector', '.dark'],
+    safelist: [
+        "hover:!bg-[rgb(229,231,235)]",
+        "hover:!bg-[#0707a5]"
+    ],
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
         laravel({
             hotFile: 'public/laravel-comments.hot', // Most important lines
             buildDirectory: '/build', // Most important lines
-            input: ['resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
Add a title attribute with date timestamp for comments and replies when `date_format` is set to 'diff' in `config/comments.php`.

When `date_format` is set to `diff`, the exact date and time are displayed on hover.